### PR TITLE
Use X11Screensaver_Timeout if control flag set (xset s on will use system defaults)

### DIFF
--- a/lightsOn.sh
+++ b/lightsOn.sh
@@ -122,12 +122,10 @@ if [ $DPMS_Control == 1 ]; then
     xset dpms $DPMS_StandbyTime $DPMS_SuspendTime $DPMS_OffTime
 fi
 
-# Setting X11 Screensaver Extension.
-X11ScreenSaver_Restart="on"
+# Setting X11 Scrensaver Extension.
 if [ $X11ScreenSaver_Control == 1 ]; then
-    log "Setting X11 Screensaver Extension to Timeout: $X11ScreenSaver_Timeout"
+    log "Setting X11 Scrensaver Extension to Timeout: $X11ScreenSaver_Timeout"
     xset s $X11ScreenSaver_Timeout
-    X11ScreenSaver_Restart=$X11ScreenSaver_Timeout
 fi
 
 # enumerate all the attached screens
@@ -199,22 +197,38 @@ checkFullscreen()
                 if [[ $var -eq 1 ]]; then
                     delayScreensaver
                     return
+                else
+                    log "checkFullscreen(): the fullscreen app is unknown or not set to trigger the delay"
+                    # enable DPMS if necessary.
+                    dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
+                    if [ $dpmsStatus == 0 ]; then
+                        log "checkFullscreen(): DPMS enabled"
+                        xset dpms
+                    fi
+                    # Turn on X11 Screensaver if necessary.
+                    X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
+                    if [ $X11ScreensaverStatus -eq 0 ]; then
+                        log "checkFullscreen(): X11 Screensaver Extension enabled"
+                        xset s on
+                    fi
+                    return
                 fi
-                log "checkFullscreen(): the fullscreen app is unknown or not set to trigger the delay"
+                # If no Fullscreen active => set dpms on.
             else
                 log "checkFullscreen(): NO fullscreen detected"
-            fi
-            # enable DPMS if necessary.
-            dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
-            if [ $dpmsStatus == 0 ]; then
-                xset dpms
-                log "checkFullscreen(): DPMS enabled"
-            fi
-            # Turn on X11 Screensaver if necessary.
-            X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
-            if [ $X11ScreensaverStatus -eq 0 ]; then
-                log "checkFullscreen(): X11 Screensaver Extension enabled"
-                xset s $X11ScreenSaver_Restart
+                # enable DPMS if necessary.
+                dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
+                if [ $dpmsStatus == 0 ]; then
+                    xset dpms
+                    log "checkFullscreen(): DPMS enabled"
+                fi
+                # Turn on X11 Screensaver if necessary.
+                X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
+                if [ $X11ScreensaverStatus -eq 0 ]; then
+                    log "checkFullscreen(): X11 Screensaver Extension enabled"
+                    xset s on
+                fi
+
             fi
         fi
     done
@@ -419,7 +433,7 @@ delayScreensaver()
     dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
     if [ $dpmsStatus == 1 ]; then
         xset -dpms
-        log "delayScreennsaver(): DPMS disabled"
+        log "delayScrennsaver(): DPMS disabled"
     fi
 
     # Turn off X11 Screensaver if necessary.

--- a/lightsOn.sh
+++ b/lightsOn.sh
@@ -122,9 +122,9 @@ if [ $DPMS_Control == 1 ]; then
     xset dpms $DPMS_StandbyTime $DPMS_SuspendTime $DPMS_OffTime
 fi
 
-# Setting X11 Scrensaver Extension.
+# Setting X11 Screensaver Extension.
 if [ $X11ScreenSaver_Control == 1 ]; then
-    log "Setting X11 Scrensaver Extension to Timeout: $X11ScreenSaver_Timeout"
+    log "Setting X11 Screensaver Extension to Timeout: $X11ScreenSaver_Timeout"
     xset s $X11ScreenSaver_Timeout
 fi
 
@@ -197,38 +197,22 @@ checkFullscreen()
                 if [[ $var -eq 1 ]]; then
                     delayScreensaver
                     return
-                else
-                    log "checkFullscreen(): the fullscreen app is unknown or not set to trigger the delay"
-                    # enable DPMS if necessary.
-                    dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
-                    if [ $dpmsStatus == 0 ]; then
-                        log "checkFullscreen(): DPMS enabled"
-                        xset dpms
-                    fi
-                    # Turn on X11 Screensaver if necessary.
-                    X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
-                    if [ $X11ScreensaverStatus -eq 0 ]; then
-                        log "checkFullscreen(): X11 Screensaver Extension enabled"
-                        xset s on
-                    fi
-                    return
                 fi
-                # If no Fullscreen active => set dpms on.
+                log "checkFullscreen(): the fullscreen app is unknown or not set to trigger the delay"
             else
                 log "checkFullscreen(): NO fullscreen detected"
-                # enable DPMS if necessary.
-                dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
-                if [ $dpmsStatus == 0 ]; then
-                    xset dpms
-                    log "checkFullscreen(): DPMS enabled"
-                fi
-                # Turn on X11 Screensaver if necessary.
-                X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
-                if [ $X11ScreensaverStatus -eq 0 ]; then
-                    log "checkFullscreen(): X11 Screensaver Extension enabled"
-                    xset s on
-                fi
-
+            fi
+            # enable DPMS if necessary.
+            dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
+            if [ $dpmsStatus == 0 ]; then
+                xset dpms
+                log "checkFullscreen(): DPMS enabled"
+            fi
+            # Turn on X11 Screensaver if necessary.
+            X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
+            if [ $X11ScreensaverStatus -eq 0 ]; then
+                log "checkFullscreen(): X11 Screensaver Extension enabled"
+                xset s on
             fi
         fi
     done
@@ -433,7 +417,7 @@ delayScreensaver()
     dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
     if [ $dpmsStatus == 1 ]; then
         xset -dpms
-        log "delayScrennsaver(): DPMS disabled"
+        log "delayScreennsaver(): DPMS disabled"
     fi
 
     # Turn off X11 Screensaver if necessary.

--- a/lightsOn.sh
+++ b/lightsOn.sh
@@ -122,10 +122,12 @@ if [ $DPMS_Control == 1 ]; then
     xset dpms $DPMS_StandbyTime $DPMS_SuspendTime $DPMS_OffTime
 fi
 
-# Setting X11 Scrensaver Extension.
+# Setting X11 Screensaver Extension.
+X11ScreenSaver_Restart="on"
 if [ $X11ScreenSaver_Control == 1 ]; then
-    log "Setting X11 Scrensaver Extension to Timeout: $X11ScreenSaver_Timeout"
+    log "Setting X11 Screensaver Extension to Timeout: $X11ScreenSaver_Timeout"
     xset s $X11ScreenSaver_Timeout
+    X11ScreenSaver_Restart=$X11ScreenSaver_Timeout
 fi
 
 # enumerate all the attached screens
@@ -197,38 +199,22 @@ checkFullscreen()
                 if [[ $var -eq 1 ]]; then
                     delayScreensaver
                     return
-                else
-                    log "checkFullscreen(): the fullscreen app is unknown or not set to trigger the delay"
-                    # enable DPMS if necessary.
-                    dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
-                    if [ $dpmsStatus == 0 ]; then
-                        log "checkFullscreen(): DPMS enabled"
-                        xset dpms
-                    fi
-                    # Turn on X11 Screensaver if necessary.
-                    X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
-                    if [ $X11ScreensaverStatus -eq 0 ]; then
-                        log "checkFullscreen(): X11 Screensaver Extension enabled"
-                        xset s on
-                    fi
-                    return
                 fi
-                # If no Fullscreen active => set dpms on.
+                log "checkFullscreen(): the fullscreen app is unknown or not set to trigger the delay"
             else
                 log "checkFullscreen(): NO fullscreen detected"
-                # enable DPMS if necessary.
-                dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
-                if [ $dpmsStatus == 0 ]; then
-                    xset dpms
-                    log "checkFullscreen(): DPMS enabled"
-                fi
-                # Turn on X11 Screensaver if necessary.
-                X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
-                if [ $X11ScreensaverStatus -eq 0 ]; then
-                    log "checkFullscreen(): X11 Screensaver Extension enabled"
-                    xset s on
-                fi
-
+            fi
+            # enable DPMS if necessary.
+            dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
+            if [ $dpmsStatus == 0 ]; then
+                xset dpms
+                log "checkFullscreen(): DPMS enabled"
+            fi
+            # Turn on X11 Screensaver if necessary.
+            X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
+            if [ $X11ScreensaverStatus -eq 0 ]; then
+                log "checkFullscreen(): X11 Screensaver Extension enabled"
+                xset s $X11ScreenSaver_Restart
             fi
         fi
     done
@@ -433,7 +419,7 @@ delayScreensaver()
     dpmsStatus=$(xset -q | grep -c 'DPMS is Enabled')
     if [ $dpmsStatus == 1 ]; then
         xset -dpms
-        log "delayScrennsaver(): DPMS disabled"
+        log "delayScreennsaver(): DPMS disabled"
     fi
 
     # Turn off X11 Screensaver if necessary.

--- a/lightsOn.sh
+++ b/lightsOn.sh
@@ -123,9 +123,11 @@ if [ $DPMS_Control == 1 ]; then
 fi
 
 # Setting X11 Screensaver Extension.
+X11ScreenSaver_RestartTimeout="on"
 if [ $X11ScreenSaver_Control == 1 ]; then
-    log "Setting X11 Screensaver Extension to Timeout: $X11ScreenSaver_Timeout"
-    xset s $X11ScreenSaver_Timeout
+    X11ScreenSaver_RestartTimeout=$X11ScreenSaver_Timeout
+    log "Setting X11 Screensaver Extension to Timeout: $X11ScreenSaver_RestartTimeout"
+    xset s $X11ScreenSaver_RestartTimeout
 fi
 
 # enumerate all the attached screens
@@ -212,7 +214,7 @@ checkFullscreen()
             X11ScreensaverStatus=$(xset q | grep timeout | sed "s/cycle.*$//" | tr -cd [:digit:])
             if [ $X11ScreensaverStatus -eq 0 ]; then
                 log "checkFullscreen(): X11 Screensaver Extension enabled"
-                xset s on
+                xset s $X11ScreenSaver_RestartTimeout
             fi
         fi
     done


### PR DESCRIPTION
I found that `xset s on`  will use the system defaults rather than the last arguments used for timeout +/- cycle.

Also, my dock uses  `_NET_WM_STATE_ABOVE` so would cause the loop in `checkFullscreen` to exit before other displays have been evaluated, so the return has been removed which allowed some consolidation of duplicated code.
